### PR TITLE
Fix regex issue for multiline comments

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,9 +2,12 @@ name: Publish Package to GitHub
 on:
   push:
     branches: ['main']
+  pull_request:
+    branches: ['main']
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Run unit tests and publish package on main
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -16,5 +19,6 @@ jobs:
       - run: npm run build
       - run: npm run test
       - run: npm publish
+        if: contains('refs/heads/main', github.ref)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-velocitas/velocitas-project-generator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-velocitas/velocitas-project-generator",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-velocitas/velocitas-project-generator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-velocitas/velocitas-project-generator-npm.git"

--- a/src/code-formatter.ts
+++ b/src/code-formatter.ts
@@ -232,10 +232,7 @@ export class CodeFormatter {
             for (let index = methodStartIndex; array[index] != ''; index++) {
                 tempMethods.push(array[index]);
                 if (array[index].includes(PYTHON.SYNC_METHOD_START)) {
-                    const subscriptionCallbackVariableLine = this.mapSubscriptionCallbackForVelocitas(array[index]).replace(
-                        PYTHON.SYNC_METHOD_START,
-                        PYTHON.ASYNC_METHOD_START
-                    );
+                    const subscriptionCallbackVariableLine = this.mapSubscriptionCallbackForVelocitas(array[index]);
                     tempModifiedMethods.push(
                         array[index]
                             .replace(PYTHON.SYNC_METHOD_START, PYTHON.ASYNC_METHOD_START)

--- a/src/code-formatter.ts
+++ b/src/code-formatter.ts
@@ -125,8 +125,7 @@ export class CodeFormatter {
         }
         try {
             const mainPyBaseStructure = decodedMainPyContentData
-                .replace(REGEX.FROM_LOGGER_TO_CLASS, `\n\n${seperateClassForTemplate}\n\n${PYTHON.CLASS}`)
-                .replace(REGEX.GET_SAMPLE_VEHICLE_APP, '')
+                .replace(REGEX.FIND_GLOBAL_TOPIC_VARIABLES, `\n\n${seperateClassForTemplate}\n\n${PYTHON.CLASS}`)
                 .replace(REGEX.GET_WHITESPACE_FOLLOWED_BY_COMMENTS, '')
                 .replace(REGEX.EVERYTHING_BETWEEN_MULTILINE, '')
                 .replace(REGEX.GET_EVERY_PYTHON_DOCSTRING, '')
@@ -150,7 +149,13 @@ export class CodeFormatter {
         const appNameForTemplate = `${appName.charAt(0).toUpperCase()}${appName.slice(1)}${VELOCITAS.VEHICLE_APP_SUFFIX}`;
         try {
             const newMainPy = extractedMainPyStructure
-                .replace(REGEX.FIND_BEGIN_OF_ON_START_METHOD, this.indentCodeSnippet(adaptedCodeSnippet, INDENTATION.COUNT_METHOD))
+                .replace(
+                    REGEX.FIND_BEGIN_OF_ON_START_METHOD,
+                    `${this.indentCodeSnippet(VELOCITAS.ON_START, INDENTATION.COUNT_CLASS)}\n${this.indentCodeSnippet(
+                        adaptedCodeSnippet,
+                        INDENTATION.COUNT_METHOD
+                    )}`
+                )
                 .replace(REGEX.FIND_SAMPLE_APP, appNameForTemplate);
             return newMainPy;
         } catch (error) {
@@ -227,7 +232,10 @@ export class CodeFormatter {
             for (let index = methodStartIndex; array[index] != ''; index++) {
                 tempMethods.push(array[index]);
                 if (array[index].includes(PYTHON.SYNC_METHOD_START)) {
-                    const subscriptionCallbackVariableLine = this.mapSubscriptionCallbackForVelocitas(array[index]);
+                    const subscriptionCallbackVariableLine = this.mapSubscriptionCallbackForVelocitas(array[index]).replace(
+                        PYTHON.SYNC_METHOD_START,
+                        PYTHON.ASYNC_METHOD_START
+                    );
                     tempModifiedMethods.push(
                         array[index]
                             .replace(PYTHON.SYNC_METHOD_START, PYTHON.ASYNC_METHOD_START)
@@ -251,11 +259,9 @@ export class CodeFormatter {
             ?.split(PYTHON.SYNC_METHOD_START)[1]
             .trim()
             .split(`(`)[0];
-
         const vssSignal = this.codeSnippetStringArray
             .find((line: string) => line.includes(`${DIGITAL_AUTO.SUBSCRIBE_CALL}${methodName}`))
             ?.split(`${DIGITAL_AUTO.SUBSCRIBE_CALL}`)[0];
-
         const callBackVariable = methodString.split(`(`)[1].split(`:`)[0].split(`)`)[0];
 
         const subscriptionCallbackVariableLine = this.indentCodeSnippet(

--- a/src/tests/code-formatter.test.ts
+++ b/src/tests/code-formatter.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 Robert Bosch GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'fs';
+import * as path from 'path';
+
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { CodeFormatter } from '../code-formatter';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+const APP_NAME = 'test';
+
+const EXAMPLE_INPUT_1 = readFileSync(`${path.join(__dirname, 'files/example_input_1.py')}`, 'base64');
+const EXAMPLE_INPUT_2 = readFileSync(`${path.join(__dirname, 'files/example_input_1.py')}`, 'base64');
+const EXPECTED_OUTPUT_1 = readFileSync(`${path.join(__dirname, 'files/example_output_1.py')}`, 'utf8');
+const EXPECTED_OUTPUT_2 = readFileSync(`${path.join(__dirname, 'files/example_output_1.py')}`, 'utf8');
+const VELOCITAS_TEMPLATE_MAINPY = readFileSync(`${path.join(__dirname, 'files/velocitas_template_main.py')}`, 'base64');
+
+describe('Code Formatter', () => {
+    it('should initialize', async () => {
+        const codeFormatter: CodeFormatter = new CodeFormatter();
+        expect(codeFormatter).to.be.instanceof(CodeFormatter);
+    });
+    it('should format main.py correctly for example 1', async () => {
+        const codeFormatter: CodeFormatter = new CodeFormatter();
+        const formattedMainPy = codeFormatter.formatMainPy(VELOCITAS_TEMPLATE_MAINPY, EXAMPLE_INPUT_1, APP_NAME);
+        const encodedExpectedOutputMainPyContentData = Buffer.from(EXPECTED_OUTPUT_1.trim(), 'utf8').toString('base64');
+        expect(formattedMainPy).to.be.equal(encodedExpectedOutputMainPyContentData);
+    });
+    it('should format main.py correctly for example 2', async () => {
+        const codeFormatter: CodeFormatter = new CodeFormatter();
+        const formattedMainPy = codeFormatter.formatMainPy(VELOCITAS_TEMPLATE_MAINPY, EXAMPLE_INPUT_2, APP_NAME);
+        const encodedExpectedOutputMainPyContentData = Buffer.from(EXPECTED_OUTPUT_2.trim(), 'utf8').toString('base64');
+        expect(formattedMainPy).to.be.equal(encodedExpectedOutputMainPyContentData);
+    });
+});

--- a/src/tests/files/example_input_1.py
+++ b/src/tests/files/example_input_1.py
@@ -1,0 +1,60 @@
+# VSS imports the playground. In production, the config can be updated to use the real VSS API
+from ACME_Car_EV_v01 import Vehicle
+from dashboard import SmartPhone, CarDash
+
+vehicle = Vehicle()
+
+def on_wiper_position_changed(position: float):
+    print("Listener was triggered")
+    print("Wiper is moving")
+    SmartPhone.set_text(f"Wiper is finished and will return to {position}")
+    CarDash.set_text(f"Wiper is finished and will return to {position}")
+    if position >= vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.get():
+        CarDash.set_text(f"Wiper {position} reached")
+
+vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.subscribe(on_wiper_position_changed)
+print("Wiper output Listener was registered")
+
+def on_wiper_start(WipeMode):
+    print("---------Wiper movement triggered------------")
+    #print(f"{vehicle.Body.Windshield.Front.Wiping.System.Mode.WIPE}")
+    #print(f"{WipeMode}-----")
+    print(f"Wiping Mode: {vehicle.Body.Windshield.Front.Wiping.System.Mode.get()}")
+    if WipeMode == "WIPE":
+        WiperTarget = vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.get()
+        print(f"Wiping Target: {WiperTarget}")
+        ActualPosition = vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.get()
+        steps = 1
+        if ActualPosition < WiperTarget:
+            steps = vehicle.Body.Windshield.Front.Wiping.System.Frequency.get() /10
+        if ActualPosition > WiperTarget:
+            steps = vehicle.Body.Windshield.Front.Wiping.System.Frequency.get() / 10 * -1
+        while ActualPosition != WiperTarget:
+            vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.set(ActualPosition)
+            print(f"Acutal wiper Pos: {vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.get()} Target: {WiperTarget}")
+            ActualPosition += steps
+            #time sleep
+        print("Finished Movement")
+
+vehicle.Body.Windshield.Front.Wiping.System.Mode.subscribe(on_wiper_start)
+
+# Turn wiper on
+print("Turn Wipers to Rain Sensor")
+vehicle.Body.Windshield.Front.Wiping.Mode.set(vehicle.Body.Windshield.Front.Wiping.Mode.RAIN_SENSOR)
+print("Start moving Wiper to Service position")
+vehicle.Body.Windshield.Front.Wiping.System.Frequency.set(45)
+
+print("Wiping 3 times")
+wipingCounter = 0
+wipingTimes = 3
+while wipingCounter <= wipingTimes:
+    print("set Wiper to End position")
+    vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.set(90)
+    print("Start Wiper movement to End position")
+    vehicle.Body.Windshield.Front.Wiping.System.Mode.set(vehicle.Body.Windshield.Front.Wiping.System.Mode.WIPE)
+    print("set Wiper to 0 position")
+    vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.set(0)
+    print("Start Wiper movement to 0 position")
+    vehicle.Body.Windshield.Front.Wiping.System.Mode.set(vehicle.Body.Windshield.Front.Wiping.System.Mode.WIPE)
+    wipingCounter += 1
+print("Finished Wiping")

--- a/src/tests/files/example_input_2.py
+++ b/src/tests/files/example_input_2.py
@@ -1,0 +1,40 @@
+import random
+from ACME_Car_EV_v01 import Vehicle
+from dashboard import SmartPhone
+
+# ABC Example
+
+class Dog:
+    def isSad(self):
+        l_mood = self.mood()
+        return (l_mood, l_mood in ["Sad", "Crying"])
+
+    def mood(self):
+        return random.choice([
+            "Happy",
+            "Sad",
+            "Crying",
+            "Frightened",
+            "Excited"
+        ])
+
+# Instantiate the classes Dog and Vehicle
+# Instantiate the vehicle and setup the initial state
+vehicle = Vehicle()
+vehicle.Cabin.Sunroof.Switch.set(vehicle.Cabin.Sunroof.Switch.CLOSE)
+
+# Instantiate the dog and get the mood
+dog = Dog()
+dog_mood, dog_is_sad = dog.isSad()
+
+
+if dog_is_sad:
+    vehicle.Cabin.Sunroof.Switch.set(vehicle.Cabin.Sunroof.Switch.OPEN)
+else:
+    vehicle.Cabin.Sunroof.Switch.set(vehicle.Cabin.Sunroof.Switch.CLOSE)
+
+print(f"INFO: 	 Is dog sad? {dog_is_sad}")
+# Display message on the smartphone
+SmartPhone.set_text(f"Dog is {dog_mood} Sunroof: {vehicle.Cabin.Sunroof.Switch.get()}")
+
+print(f"INFO: 	 What is Sunroof's Status? {vehicle.Cabin.Sunroof.Switch.get()}")

--- a/src/tests/files/example_output_1.py
+++ b/src/tests/files/example_output_1.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+
+# pylint: disable=C0103, C0413, E1101
+
+import asyncio
+import json
+import logging
+import signal
+
+from sdv.util.log import (  # type: ignore
+    get_opentelemetry_log_factory,
+    get_opentelemetry_log_format,
+)
+from sdv.vdb.subscriptions import DataPointReply
+from sdv.vehicle_app import VehicleApp, subscribe_topic
+from sdv_model import Vehicle, vehicle  # type: ignore
+
+# Configure the VehicleApp logger with the necessary log config and level.
+logging.setLogRecordFactory(get_opentelemetry_log_factory())
+logging.basicConfig(format=get_opentelemetry_log_format())
+logging.getLogger().setLevel("DEBUG")
+logger = logging.getLogger(__name__)
+
+
+
+class TestApp(VehicleApp):
+
+
+    def __init__(self, vehicle_client: Vehicle):
+        super().__init__()
+        self.Vehicle = vehicle_client
+
+    async def on_start(self):
+        await self.Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.subscribe(self.on_wiper_position_changed)
+        logger.info("Wiper output Listener was registered")
+
+
+        await self.Vehicle.Body.Windshield.Front.Wiping.System.Mode.subscribe(self.on_wiper_start)
+
+        logger.info("Turn Wipers to Rain Sensor")
+        await self.Vehicle.Body.Windshield.Front.Wiping.Mode.set(self.Vehicle.Body.Windshield.Front.Wiping.Mode.RAIN_SENSOR)
+        logger.info("Start moving Wiper to Service position")
+        await self.Vehicle.Body.Windshield.Front.Wiping.System.Frequency.set(45)
+
+        logger.info("Wiping 3 times")
+        wipingCounter = 0
+        wipingTimes = 3
+        while wipingCounter <= wipingTimes:
+            logger.info("set Wiper to End position")
+            await self.Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.set(90)
+            logger.info("Start Wiper movement to End position")
+            await self.Vehicle.Body.Windshield.Front.Wiping.System.Mode.set(self.Vehicle.Body.Windshield.Front.Wiping.System.Mode.WIPE)
+            logger.info("set Wiper to 0 position")
+            await self.Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.set(0)
+            logger.info("Start Wiper movement to 0 position")
+            await self.Vehicle.Body.Windshield.Front.Wiping.System.Mode.set(self.Vehicle.Body.Windshield.Front.Wiping.System.Mode.WIPE)
+            wipingCounter += 1
+        logger.info("Finished Wiping")
+
+    async def on_wiper_position_changed(self, data: DataPointReply):
+        position = data.get(self.Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition)
+        logger.info("Listener was triggered")
+        logger.info("Wiper is moving")
+        await self.publish_mqtt_event("SmartPhone", json.dumps({"result": {"message": f"""Wiper is finished and will return to {position}"""}}))
+        await self.publish_mqtt_event("CarDash", json.dumps({"result": {"message": f"""Wiper is finished and will return to {position}"""}}))
+        if position >= await self.Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.get():
+            await self.publish_mqtt_event("CarDash", json.dumps({"result": {"message": f"""Wiper {position} reached"""}}))
+
+    async def on_wiper_start(self, data: DataPointReply):
+        WipeMode = data.get(self.Vehicle.Body.Windshield.Front.Wiping.System.Mode)
+        logger.info("---------Wiper movement triggered------------")
+        logger.info("Wiping Mode: {await self.Vehicle.Body.Windshield.Front.Wiping.System.Mode.get()}")
+        if WipeMode == "WIPE":
+            WiperTarget = await self.Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition.get()
+            logger.info("Wiping Target: {WiperTarget}")
+            ActualPosition = await self.Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.get()
+            steps = 1
+            if ActualPosition < WiperTarget:
+                steps = await self.Vehicle.Body.Windshield.Front.Wiping.System.Frequency.get() /10
+            if ActualPosition > WiperTarget:
+                steps = await self.Vehicle.Body.Windshield.Front.Wiping.System.Frequency.get() / 10 * -1
+            while ActualPosition != WiperTarget:
+                await self.Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.set(ActualPosition)
+                logger.info("Acutal wiper Pos: {await self.Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition.get()} Target: {WiperTarget}")
+                ActualPosition += steps
+            logger.info("Finished Movement")
+
+async def main():
+
+
+    logger.info("Starting TestApp...")
+    vehicle_app = TestApp(vehicle)
+    await vehicle_app.run()
+
+
+LOOP = asyncio.get_event_loop()
+LOOP.add_signal_handler(signal.SIGTERM, LOOP.stop)
+LOOP.run_until_complete(main())
+LOOP.close()

--- a/src/tests/files/example_output_2.py
+++ b/src/tests/files/example_output_2.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+
+# pylint: disable=C0103, C0413, E1101
+
+import random
+import asyncio
+import json
+import logging
+import signal
+
+from sdv.util.log import (  # type: ignore
+    get_opentelemetry_log_factory,
+    get_opentelemetry_log_format,
+)
+from sdv.vdb.subscriptions import DataPointReply
+from sdv.vehicle_app import VehicleApp, subscribe_topic
+from sdv_model import Vehicle, vehicle  # type: ignore
+
+# Configure the VehicleApp logger with the necessary log config and level.
+logging.setLogRecordFactory(get_opentelemetry_log_factory())
+logging.basicConfig(format=get_opentelemetry_log_format())
+logging.getLogger().setLevel("DEBUG")
+logger = logging.getLogger(__name__)
+
+class Dog:
+    def isSad(self):
+        l_mood = self.mood()
+        return (l_mood, l_mood in ["Sad", "Crying"])
+
+    def mood(self):
+        return random.choice([
+            "Happy",
+            "Sad",
+            "Crying",
+            "Frightened",
+            "Excited"
+        ])
+
+class TestApp(VehicleApp):
+
+
+    def __init__(self, vehicle_client: Vehicle):
+        super().__init__()
+        self.Vehicle = vehicle_client
+
+    async def on_start(self):
+        await self.Vehicle.Cabin.Sunroof.Switch.set(self.Vehicle.Cabin.Sunroof.Switch.CLOSE)
+
+        dog = Dog()
+        dog_mood, dog_is_sad = dog.isSad()
+
+
+        if dog_is_sad:
+            await self.Vehicle.Cabin.Sunroof.Switch.set(self.Vehicle.Cabin.Sunroof.Switch.OPEN)
+        else:
+            await self.Vehicle.Cabin.Sunroof.Switch.set(self.Vehicle.Cabin.Sunroof.Switch.CLOSE)
+
+        logger.info("INFO: 	 Is dog sad? {dog_is_sad}")
+        await self.publish_mqtt_event("SmartPhone", json.dumps({"result": {"message": f"""Dog is {dog_mood} Sunroof: {await self.Vehicle.Cabin.Sunroof.Switch.get()}"""}}))
+
+        logger.info("INFO: 	 What is Sunroof's Status? {await self.Vehicle.Cabin.Sunroof.Switch.get()}")
+
+
+
+async def main():
+
+
+    logger.info("Starting TestApp...")
+    vehicle_app = TestApp(vehicle)
+    await vehicle_app.run()
+
+
+LOOP = asyncio.get_event_loop()
+LOOP.add_signal_handler(signal.SIGTERM, LOOP.stop)
+LOOP.run_until_complete(main())
+LOOP.close()

--- a/src/tests/files/velocitas_template_main.py
+++ b/src/tests/files/velocitas_template_main.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A sample skeleton vehicle app."""
+
+# pylint: disable=C0103, C0413, E1101
+
+import asyncio
+import json
+import logging
+import signal
+
+from sdv.util.log import (  # type: ignore
+    get_opentelemetry_log_factory,
+    get_opentelemetry_log_format,
+)
+from sdv.vdb.subscriptions import DataPointReply
+from sdv.vehicle_app import VehicleApp, subscribe_topic
+from sdv_model import Vehicle, vehicle  # type: ignore
+
+# Configure the VehicleApp logger with the necessary log config and level.
+logging.setLogRecordFactory(get_opentelemetry_log_factory())
+logging.basicConfig(format=get_opentelemetry_log_format())
+logging.getLogger().setLevel("DEBUG")
+logger = logging.getLogger(__name__)
+
+GET_SPEED_REQUEST_TOPIC = "sampleapp/getSpeed"
+GET_SPEED_RESPONSE_TOPIC = "sampleapp/getSpeed/response"
+DATABROKER_SUBSCRIPTION_TOPIC = "sampleapp/currentSpeed"
+
+
+class SampleApp(VehicleApp):
+    """
+    Sample skeleton vehicle app.
+    The skeleton subscribes to a getSpeed MQTT topic
+    to listen for incoming requests to get
+    the current vehicle speed and publishes it to
+    a response topic.
+    It also subcribes to the VehicleDataBroker
+    directly for updates of the
+    Vehicle.OBD.Speed signal and publishes this
+    information via another specific MQTT topic
+    """
+
+    def __init__(self, vehicle_client: Vehicle):
+        # SampleApp inherits from VehicleApp.
+        super().__init__()
+        self.Vehicle = vehicle_client
+
+    async def on_start(self):
+        """Run when the vehicle app starts"""
+        # This method will be called by the SDK when the connection to the
+        # Vehicle DataBroker is ready.
+        # Here you can subscribe for the Vehicle Signals update (e.g. Vehicle Speed).
+        await self.Vehicle.OBD.Speed.subscribe(self.on_speed_change)
+
+    async def on_speed_change(self, data: DataPointReply):
+        """The on_speed_change callback, this will be executed when receiving a new
+        vehicle signal updates."""
+        # Get the current vehicle speed value from the received DatapointReply.
+        # The DatapointReply containes the values of all subscribed DataPoints of
+        # the same callback.
+        vehicle_speed = data.get(self.Vehicle.OBD.Speed)
+
+        # Do anything with the received value.
+        # Example:
+        # - Publishes current speed to MQTT Topic (i.e. DATABROKER_SUBSCRIPTION_TOPIC).
+        await self.publish_mqtt_event(
+            DATABROKER_SUBSCRIPTION_TOPIC,
+            json.dumps({"speed": vehicle_speed}),
+        )
+
+    @subscribe_topic(GET_SPEED_REQUEST_TOPIC)
+    async def on_get_speed_request_received(self, data: str) -> None:
+        """The subscribe_topic annotation is used to subscribe for incoming
+        PubSub events, e.g. MQTT event for GET_SPEED_REQUEST_TOPIC.
+        """
+
+        # Use the logger with the preferred log level (e.g. debug, info, error, etc)
+        logger.debug(
+            "PubSub event for the Topic: %s -> is received with the data: %s",
+            GET_SPEED_REQUEST_TOPIC,
+            data,
+        )
+
+        # Getting current speed from VehicleDataBroker using the DataPoint getter.
+        vehicle_speed = await self.Vehicle.OBD.Speed.get()
+
+        # Do anything with the speed value.
+        # Example:
+        # - Publishe the vehicle speed to MQTT topic (i.e. GET_SPEED_RESPONSE_TOPIC).
+        await self.publish_mqtt_event(
+            GET_SPEED_RESPONSE_TOPIC,
+            json.dumps(
+                {
+                    "result": {
+                        "status": 0,
+                        "message": f"""Current Speed = {vehicle_speed}""",
+                    },
+                }
+            ),
+        )
+
+
+async def main():
+
+    """Main function"""
+    logger.info("Starting SampleApp...")
+    # Constructing SampleApp and running it.
+    vehicle_app = SampleApp(vehicle)
+    await vehicle_app.run()
+
+
+LOOP = asyncio.get_event_loop()
+LOOP.add_signal_handler(signal.SIGTERM, LOOP.stop)
+LOOP.run_until_complete(main())
+LOOP.close()

--- a/src/tests/regex.test.ts
+++ b/src/tests/regex.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 Robert Bosch GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { REGEX } from '../utils/regex';
+
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+const multiline = `
+DO NOT REPLACE
+"""
+This text can be replaced
+This text can be replaced
+This text can be replaced
+This text can be replaced
+This text can be replaced
+This text can be replaced
+This text can be replaced
+"""
+DO NOT REPLACE
+`;
+const indentedMultiline = `
+    DO NOT REPLACE
+    """
+    This text can be replaced
+    This text can be replaced
+    This text can be replaced
+    This text can be replaced
+    This text can be replaced
+    This text can be replaced
+    This text can be replaced
+    """
+    DO NOT REPLACE
+`;
+
+const multilineOneLine = `DO NOT REPLACE """ This text can be replaced """ DO NOT REPLACE`;
+const indentedMultilineOneLine = `  DO NOT REPLACE """ This text can be replaced """ DO NOT REPLACE`;
+
+const multilineTwoLines = `
+DO NOT REPLACE
+""" This text can be replaced
+This text can be replaced """
+DO NOT REPLACE
+`;
+const indentedMultilineTwoLines = `
+    DO NOT REPLACE
+    """ This text can be replaced
+    This text can be replaced """
+    DO NOT REPLACE
+`;
+
+const expectedMultilineOutput = `
+DO NOT REPLACE
+
+DO NOT REPLACE
+`;
+const expectedIndentedMultilineOutput = `
+    DO NOT REPLACE
+
+    DO NOT REPLACE
+`;
+
+const expectedOneLineOutput = 'DO NOT REPLACE DO NOT REPLACE';
+const expectedIndentedOneLineOutput = '  DO NOT REPLACE DO NOT REPLACE';
+
+describe('Regex', () => {
+    it('should find and replace multiline comments', async () => {
+        const formattedMultiline = multiline.replace(REGEX.EVERYTHING_BETWEEN_MULTILINE, '');
+        const formattedIndentedMultiline = indentedMultiline.replace(REGEX.EVERYTHING_BETWEEN_MULTILINE, '');
+
+        const formattedMultilineOneLine = multilineOneLine.replace(REGEX.EVERYTHING_BETWEEN_MULTILINE, '');
+        const formattedIndentedMultilineOneLine = indentedMultilineOneLine.replace(REGEX.EVERYTHING_BETWEEN_MULTILINE, '');
+
+        const formattedMultilineTwoLines = multilineTwoLines.replace(REGEX.EVERYTHING_BETWEEN_MULTILINE, '');
+        const formattedIndentedMultilineTwoLines = indentedMultilineTwoLines.replace(REGEX.EVERYTHING_BETWEEN_MULTILINE, '');
+
+        expect(formattedMultiline).to.be.equal(expectedMultilineOutput);
+        expect(formattedIndentedMultiline).to.be.equal(expectedIndentedMultilineOutput);
+
+        expect(formattedMultilineOneLine).to.be.equal(expectedOneLineOutput);
+        expect(formattedIndentedMultilineOneLine).to.be.equal(expectedIndentedOneLineOutput);
+
+        expect(formattedMultilineTwoLines).to.be.equal(expectedMultilineOutput);
+        expect(formattedIndentedMultilineTwoLines).to.be.equal(expectedIndentedMultilineOutput);
+    });
+});

--- a/src/utils/codeConstants.ts
+++ b/src/utils/codeConstants.ts
@@ -22,6 +22,7 @@ export const PYTHON = {
 };
 export const VELOCITAS = {
     MAIN_METHOD: 'async def main():',
+    ON_START: 'async def on_start(self):',
     VEHICLE_APP_SUFFIX: 'App',
     CLASS_METHOD_SIGNATURE: '(self, data: DataPointReply)',
     SUBSCRIPTION_SIGNATURE: '.subscribe(self.',

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -14,19 +14,17 @@
 
 export const REGEX = {
     // Get everything between logger and class from template
-    FROM_LOGGER_TO_CLASS: /(?<=\_\))[\r\n]+(^[\S\s*]*class)/gm,
-    // Get """Sample Vehicle App""" from template
-    GET_SAMPLE_VEHICLE_APP: /(^\"\"\").*[\r\n]+[\r\n]/gm,
+    FIND_GLOBAL_TOPIC_VARIABLES: /(?<=\_\))[\r\n]+(^[\S\s*]*class)/gm,
     // Remove all lines with whitespaces followed by # (comments) from template
     GET_WHITESPACE_FOLLOWED_BY_COMMENTS: /^(?:[\t ]*(?:\r?|\r).\#.*\n?)+/gm,
     // Everything between multiline comment from template
-    EVERYTHING_BETWEEN_MULTILINE: /(?=\"\"\")[\S\s]*(?<=[\s]\"\"\"$)[\S\s]/gm,
+    EVERYTHING_BETWEEN_MULTILINE: /([\t ]*\"\"\"[\s\S]*?\"\"\")/gm,
     // Every """ (docstring) from template
     GET_EVERY_PYTHON_DOCSTRING: /^(?:[\t ]*(?:\r?|\r).\"\"\".*\n?)+/gm,
     // Get everything between on_speed_change and "async def main():" from template
     GET_EVERY_DELETABLE_TEMPLATE_CODE: /(?<=\(self\.on\_speed\_change\))[\r\n]+(^[\S\s*]*async def main\(\)\:)/gm,
     // Replace content in on_start method (Here digital.auto code comes in)
-    FIND_BEGIN_OF_ON_START_METHOD: /[\t ]*logger\.info\(\"SampleApp started\.\"\)[\r\n]+([^\r\n]+)/gm,
+    FIND_BEGIN_OF_ON_START_METHOD: /[\t ]*async def on\_start\(self\)\:[\r\n]+([^\r\n]+)/gm,
     FIND_VEHICLE_OCCURENCE: /vehicle/gm,
     FIND_UNWANTED_VEHICLE_CHANGE: /\(await self\.Vehicle/gm,
     FIND_PRINTF_STATEMENTS: /print\(f/gm,

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -18,7 +18,7 @@ export const REGEX = {
     // Remove all lines with whitespaces followed by # (comments) from template
     GET_WHITESPACE_FOLLOWED_BY_COMMENTS: /^(?:[\t ]*(?:\r?|\r).\#.*\n?)+/gm,
     // Everything between multiline comment from template
-    EVERYTHING_BETWEEN_MULTILINE: /([\t ]*\"\"\"[\s\S]*?\"\"\")/gm,
+    EVERYTHING_BETWEEN_MULTILINE: /([^\S\r\n]*\"\"\"[\s\S]*?\"\"\")/gm,
     // Every """ (docstring) from template
     GET_EVERY_PYTHON_DOCSTRING: /^(?:[\t ]*(?:\r?|\r).\"\"\".*\n?)+/gm,
     // Get everything between on_speed_change and "async def main():" from template


### PR DESCRIPTION
Signed-off-by: Dennis Meister <dennis.meister@bosch.com>

Fixing regex issue for multiline comments, subscriptionCallbackVariableLine and adapt to latest python template

removed the GET_SAMPLE_VEHICLE_APP replacement because of newly introduced regex for removing multiline-comments.

updated code to find the begin of the on_start method by directly searching for the method name instead of the logging line.

Also add running workflow on PR