### PR TITLE
[Fix] Bump serialize-javascript from 6.0.0 to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,7 +1996,7 @@
         "minimatch": "5.0.1",
         "ms": "2.1.3",
         "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
+        "serialize-javascript": "6.0.2",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "workerpool": "6.2.1",


### PR DESCRIPTION
Fix vulnerability:
https://github.com/eclipse-velocitas/velocitas-project-generator-npm/security/dependabot/10